### PR TITLE
support external mods registering resource crops

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,8 +24,8 @@ The `resourcecrops.add_crop()` function automatically handles most of creating a
 See examples in [init.lua](init.lua). 
 - Note for examples from source code: This mod uses a translator `S("input_text")` for descriptions when calling `add_crop()`. This is not required, just use a string if you are not using a translator.
 ``` lua
-resourcecrops.add_crop(seed_description, essence_description, resource_name,   essence_level, recipe_input,        recipe_output        )
-  -- example:         ("Coal Seeds",     "Coal Essence",      "coal",          "weak",        "default:coal_lump", "default:coal_lump 2")
+resourcecrops.add_crop(seed_description, essence_description, resource_name,   essence_level, recipe_input,        recipe_output,         mod_name)
+  -- example:         ("Coal Seeds",     "Coal Essence",      "coal",          "weak",        "default:coal_lump", "default:coal_lump 2", "resource_crops")
 ```
 
 ### Parameters
@@ -35,6 +35,7 @@ resourcecrops.add_crop(seed_description, essence_description, resource_name,   e
  - `essence_level`: The essence used in the crafting [Recipe](#recipes) for the seed. Essence levels are `weak`, `regular`, `strong`, and `extreme`.
  - `recipe_input`: The itemstring of the resource item used in the crafting [Recipe](#recipes) for the seed. If not defined or `nil`, the recipe for the seed will not be registered automatically.
  - `recipe_output`: The itemstring of the output of crafting 9 resource essence together, optionally including the number of items. If not defined or `nil`, the recipe will not be registered automatically.
+ - `mod_name`: The name of the mod the new items should be created in
 
 ### Created Items
 | Item Name             | Itemstring                                          | Name Example (Coal) | Itemstring Example (Coal)            |

--- a/lib.lua
+++ b/lib.lua
@@ -35,10 +35,14 @@ function resourcecrops.check_crop_node(pos)
 end
 
 
-function resourcecrops.add_crop(seed_description, essence_description, resource_name,   essence_level, recipe_input,        recipe_output        )
-  -- example: 								 ("Coal Seeds",     "Coal Essence",      "coal",          "weak",        "default:coal_lump", "default:coal_lump 2")
+function resourcecrops.add_crop(seed_description, essence_description, resource_name,   essence_level, recipe_input,        recipe_output,         mod_name)
+  -- example:                  ("Coal Seeds",     "Coal Essence",      "coal",          "weak",        "default:coal_lump", "default:coal_lump 2")
+
+  if not mod_name then
+    mod_name = "resource_crops"
+  end
   
-  local essence_item = "resource_crops:"..resource_name.."_essence"
+  local essence_item = mod_name..":"..resource_name.."_essence"
   local essence_ingredient = "resource_crops:essence_"..essence_level
 
   -- Register Plant
@@ -49,7 +53,7 @@ function resourcecrops.add_crop(seed_description, essence_description, resource_
     harvest_description = essence_description,
     paramtype2 = "meshoptions",
     place_param2 = 0,
-    inventory_image = "resource_crops_"..resource_name.."_seed.png",
+    inventory_image = mod_name.."_"..resource_name.."_seed.png",
     steps = 4,
     minlight = 8,
     maxlight = default.LIGHT_MAX,
@@ -91,11 +95,13 @@ function resourcecrops.add_crop(seed_description, essence_description, resource_
     }
   })
 
-  -- Register aliases for v1.x.x
-  core.register_alias("resource_crops:"..resource_name.."_seed", seed_item)
-  core.register_alias("resource_crops:"..resource_name.."crop_1", essence_item.."_1")
-  core.register_alias("resource_crops:"..resource_name.."crop_2", essence_item.."_2")
-  core.register_alias("resource_crops:"..resource_name.."crop_3", essence_item.."_3")
-  core.register_alias("resource_crops:"..resource_name.."crop", essence_item.."_4")
+  if mod_name == "resource_crops" then
+    -- Register aliases for v1.x.x
+    core.register_alias("resource_crops:"..resource_name.."_seed", seed_item)
+    core.register_alias("resource_crops:"..resource_name.."crop_1", essence_item.."_1")
+    core.register_alias("resource_crops:"..resource_name.."crop_2", essence_item.."_2")
+    core.register_alias("resource_crops:"..resource_name.."crop_3", essence_item.."_3")
+    core.register_alias("resource_crops:"..resource_name.."crop", essence_item.."_4")
+  end
 end
 


### PR DESCRIPTION
Currently `resource_crops_additions` errors in Luanti 5.15.1 because `resource_crops` provides no way to register items in a mod other than `resource_crops` itself:
<details>

<summary><code>resource_crops_additions</code> errors </summary>

```
2026-03-27 19:02:59: ERROR[Main]: ModError: Failed to load and run script from /home/jacob/.var/app/org.luanti.luanti/.minetest/mods/resource_crops_additions/init.lua:
2026-03-27 19:02:59: ERROR[Main]: /app/share/luanti/builtin/game/register.lua:67: Name resource_crops:etherium_essence_1 does not follow naming conventions: "resource_crops_additions:" or ":" prefix required
2026-03-27 19:02:59: ERROR[Main]: stack traceback:
2026-03-27 19:02:59: ERROR[Main]: 	[C]: in function 'error'
2026-03-27 19:02:59: ERROR[Main]: 	/app/share/luanti/builtin/game/register.lua:67: in function 'check_modname_prefix'
2026-03-27 19:02:59: ERROR[Main]: 	/app/share/luanti/builtin/game/register.lua:240: in function 'register_node'
2026-03-27 19:02:59: ERROR[Main]: 	...uanti.luanti/.minetest/games/asuna/mods/farming/init.lua:678: in function 'register_plant'
2026-03-27 19:02:59: ERROR[Main]: 	.../org.luanti.luanti/.minetest/mods/resource_crops/lib.lua:59: in function 'add_crop'
2026-03-27 19:02:59: ERROR[Main]: 	....luanti/.minetest/mods/resource_crops_additions/init.lua:7: in main chunk
```

</details>

This PR helps fix that by adding a new argument to `resourcecrops.add_crop` for the mod name to register items in.